### PR TITLE
Implement UITabBarControllerDelegate.tabBarController(_:shouldSelect:)

### DIFF
--- a/BubbleTabBar/Classes/BubbleTabBar.swift
+++ b/BubbleTabBar/Classes/BubbleTabBar.swift
@@ -155,16 +155,6 @@ open class BubbleTabBar: UITabBar {
             let item = items?[index] else {
                 return
         }
-        buttons.forEach { (button) in
-            guard button != sender else {
-                return
-            }
-            button.setSelected(false, animationDuration: animationDuration)
-        }
-        sender.setSelected(true, animationDuration: animationDuration)
-        UIView.animate(withDuration: animationDuration) {
-            self.container.layoutIfNeeded()
-        }
         delegate?.tabBar?(self, didSelect: item)
     }
     

--- a/BubbleTabBar/Classes/BubbleTabBarController.swift
+++ b/BubbleTabBar/Classes/BubbleTabBarController.swift
@@ -89,6 +89,13 @@ open class BubbleTabBarController: UITabBarController {
             return
         }
         if let controller = viewControllers?[idx] {
+            if let delegate = delegate, let should = delegate.tabBarController?(self, shouldSelect: controller), !should {
+                return
+            }
+            guard let tabBar = tabBar as? BubbleTabBar else {
+                return
+            }
+            tabBar.select(itemAt: idx, animated: true)
             shouldSelectOnTabBar = false
             selectedIndex = idx
             delegate?.tabBarController?(self, didSelect: controller)


### PR DESCRIPTION
This PR adds support for the [`UITabBarControllerDelegate.tabBarController(_:shouldSelect:)`](https://developer.apple.com/documentation/uikit/uitabbarcontrollerdelegate/1621166-tabbarcontroller) method.